### PR TITLE
Add zip to the image

### DIFF
--- a/Dockerfile.alpine
+++ b/Dockerfile.alpine
@@ -5,7 +5,7 @@ RUN CGO_ENABLED=0 go build -o /bin/docatl
 
 FROM alpine:latest
 RUN apk update \
-    && apk add -U --no-cache ca-certificates
+    && apk add -U --no-cache ca-certificates zip
 COPY --from=build /bin/docatl /bin/docatl
 WORKDIR /docs
 CMD [ "/bin/docatl" ]


### PR DESCRIPTION
In order to be able to compress large documentation directories to increase upload speed and not exceed file size limits that may be enforced by a proxy.